### PR TITLE
Scoreboard auto hiding

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/hud/Scoreboard.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/Scoreboard.java
@@ -58,6 +58,11 @@ public class Scoreboard extends HudConfig {
         )
         public boolean persistentTitle = false;
 
+        @Slider(name = "Max. ScoreBoard Height", min = 0, max = 50, step = 1)
+        public int maxScoreHeight = 15;
+        @Info(text = "Hides the ScoreBoard if it exceeds the limit", type = InfoType.INFO)
+        public boolean a;
+
         @Color(
                 name = "Title Background Color"
         )
@@ -116,7 +121,7 @@ public class Scoreboard extends HudConfig {
             boolean showRealScoreboard = objective != null;
             if (showRealScoreboard) {
                 Collection<Score> sortedScores = objective.getScoreboard().getSortedScores(objective);
-                showRealScoreboard = sortedScores.size() <= 15 && (sortedScores.size() > 0 || (this.persistentTitle && this.scoreboardTitle));
+                showRealScoreboard = sortedScores.size() <= this.maxScoreHeight && (sortedScores.size() > 0 || (this.persistentTitle && this.scoreboardTitle));
             }
             return showRealScoreboard && super.shouldShow();
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
My Scoreboard was randomly getting disappeared while playing. then i noticed that it would disappear when my scoreboard crosses the height of 15. 

Added a slider to set maximum height for scoreboard
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No related Issues

## How to test
<!-- Provide steps to test this PR -->
Add a scoreboard with more than 15 entries

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
added a slider to change maximum height for scoreboard before it hides
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
no