### PR TITLE
Fix tab name clipping on Minecraft 1.21.6+

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/mixin/elements/PlayerTabOverlayMixin.java
+++ b/src/main/java/org/polyfrost/vanillahud/mixin/elements/PlayerTabOverlayMixin.java
@@ -199,15 +199,18 @@ public abstract class PlayerTabOverlayMixin {
 
     // At clamped GUI scales names overflow their column into the numeric ping. Clip them.
     @WrapOperation(
-            //? if <26 {
+            //? if <1.21.6 {
             /*method = "render",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;III)I", ordinal = 0)
+            *///?} else if <26 {
+            /*method = "render",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;III)V", ordinal = 0)
             *///?} else {
             method = "extractRenderState",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;text(Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;III)V", ordinal = 0)
             //?}
     )
-    //? if <26 {
+    //? if <1.21.6 {
     /*private int vanillahud$clipName(GuiGraphicsExtractor graphics, Font font, Component name, int x, int y, int color,
                                    Operation<Integer> original, @Share("vhTabSlotRight") LocalIntRef slotRight) {
         int clipRight = slotRight.get() - vanillahud$pingReserve();

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -1,7 +1,7 @@
 mod.id = "vanillahud"
 mod.name = "VanillaHUD"
 mod.group = "org.polyfrost"
-mod.version = "3.2"
+mod.version = "3.1.0"
 
 deps.fabric_loader = "0.19.3"
 deps.oneconfig = "1.0.1"

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -1,7 +1,7 @@
 mod.id = "vanillahud"
 mod.name = "VanillaHUD"
 mod.group = "org.polyfrost"
-mod.version = "3.1.0"
+mod.version = "3.2"
 
 deps.fabric_loader = "0.19.3"
 deps.oneconfig = "1.0.1"


### PR DESCRIPTION
## Summary
- use the void-returning GuiGraphics.drawString descriptor introduced in Minecraft 1.21.6
- retain the int-returning callback for Minecraft 1.21.5 and earlier
- bump the mod version to 3.2

## Verification
- built the full 1.21.11 artifact successfully
- compiled the 1.21.5, 1.21.8, and 26.1 targets
- runtime-tested the 1.21.11 JAR in OneClient; startup succeeds with the previously crashing mod set